### PR TITLE
Only run the go workflow on main and PR targeting main.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,11 @@
 name: Build and Test
-on: ["push", "pull_request"]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
This should remove the duplicated "jobs" on pull-requests.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
