### PR TITLE
Detect versions directly from go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -59,13 +59,3 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v3
-
-      - name: Build
-        run: |
-          make
-          [[ $(git status --porcelain) != "" ]] && {
-              echo "There is changes in the repo like new vendor files or version not regenerated"
-              git status --verbose
-              git diff  pkg/version.json
-              exit 1
-          } || true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,8 @@
+# Bumping versions
+
+To bump versions you just need to run `make version-updates` and commit the
+change to vendor and go.mod.
+
+When building the binary, the Makefile will detect the versions from the go.mod and
+generate a file in pkg/version.json which is used to show the different version
+components.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-## Update Versions here. If you bump to a new version you need to do make
-## generate and commit the new files
-PAC_VERSION := 0.15.3
-TKN_VERSION := 0.29.0
+PAC_VERSION := $(shell sed -n '/[ ]*github.com\/openshift-pipelines\/pipelines-as-code v[0-9]*\.[0-9]*\.[0-9]*/ { s/.* v//;p ;}' go.mod)
+TKN_VERSION := $(shell sed -n '/[ ]*github.com\/tektoncd\/cli v[0-9]*\.[0-9]*\.[0-9]*/ { s/.* v//;p ;}' go.mod)
 
 GO := go
 GOVERSION := 1.18
@@ -13,7 +11,7 @@ FLAGS := -ldflags "-X github.com/tektoncd/cli/pkg/cmd/version.clientVersion=$(TK
 		   -X github.com/openshift-pipelines/pipelines-as-code/pkg/params/version.Version=$(PAC_VERSION) \
 		   -X github.com/openshift-pipelines/pipelines-as-code/pkg/params/settings.TknBinaryName=$(BINARYNAME)" $(LDFLAGS)
 
-all: vendor generate build
+all: build
 
 vendor: tidy
 	$(GO) mod vendor
@@ -21,21 +19,22 @@ vendor: tidy
 mkbin:
 	mkdir -p ./bin
 
-build: mkbin
+build: mkbin generate
 	$(GO) build -v $(FLAGS) -mod=vendor -o bin/$(BINARYNAME) main.go
 
-windows: mkbin
+windows: mkbin generate
 	env GOOS=windows GOARCH=amd64 $(GO) build -mod=vendor $(FLAGS)  -v -o bin/$(BINARYNAME).exe main.go
 
-generate: version-file version-updates
+generate: version-file
 version-file:
 	echo '{"pac": "$(PAC_VERSION)", "tkn": "$(TKN_VERSION)", "opc": "$(OPC_VERSION)"}' > pkg/version.json
 
 version-updates:
-	$(GO) get -u github.com/openshift-pipelines/pipelines-as-code@v$(PAC_VERSION)
+	$(GO) get -u github.com/openshift-pipelines/pipelines-as-code
 	$(GO) mod vendor
-	$(GO) get -u github.com/tektoncd/cli@v$(TKN_VERSION)
+	$(GO) get -u github.com/tektoncd/cli
 	$(GO) mod vendor
+	$(GO) mod tidy
 
 tidy:
 	$(GO) mod tidy -compat=$(GOVERSION)


### PR DESCRIPTION
No need to have the version file run manually anymore.

This should work with dependabot.

Add DEVELOPMENT.md to explain how things works.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>