### PR TITLE
Fix opc pac command to show the help message

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		cmd = opccli.VersionCommand(paciostreams)
 		goto CoreTkn
 	}
-	if len(args) >= 1 && args[0] == "pac" && args[1] == "version" {
+	if len(args) > 1 && args[0] == "pac" && args[1] == "version" {
 		// Arthur: "I've Got Nothing Left To Lose. Nothing Can Hurt Me Anymore. My Life Is Nothing But A Comedy." 🃏
 		os.Args = []string{"version"}
 		vcmd := opccli.VersionCommand(paciostreams)


### PR DESCRIPTION
This patch will fix `opc pac` command to show the help message
previously it was failing with an error