### PR TITLE
go.mod: update github.com/tektoncd/cli to v0.30.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 require (
 	github.com/openshift-pipelines/pipelines-as-code v0.17.2
 	github.com/spf13/cobra v1.7.0
-	github.com/tektoncd/cli v0.30.0
+	github.com/tektoncd/cli v0.30.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2340,8 +2340,8 @@ github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ
 github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955uh98WQvzOm0dgAeLnf2O0Rz0LPoC5ze+0=
 github.com/tektoncd/chains v0.15.0 h1:1x22WlNqiE7+HUBBkK6MbDi6rMqTirWWX3f/t8cDlbc=
 github.com/tektoncd/chains v0.15.0/go.mod h1:PA0su6Q+acJh2eG6d4VK1s6Jq0lGRaQml2FSQDWVTiQ=
-github.com/tektoncd/cli v0.30.0 h1:D4jln/vaAenSBVTNEEzq6rYczlNZ70IOQh5Fif7QL3E=
-github.com/tektoncd/cli v0.30.0/go.mod h1:AZRVXTJ4Lwthn33z3q7eyFFdH5CS0BJ1rt2MJc7tkFA=
+github.com/tektoncd/cli v0.30.1 h1:5MUDbcw3CXogagDBQhFbYLx+OcFASuFhyb6qkqqV6ao=
+github.com/tektoncd/cli v0.30.1/go.mod h1:AZRVXTJ4Lwthn33z3q7eyFFdH5CS0BJ1rt2MJc7tkFA=
 github.com/tektoncd/hub v1.12.1 h1:ItKjjIFSNnjq8yU+LvvIN+sqvxtCHDpWNMopo/xRWk8=
 github.com/tektoncd/hub v1.12.1/go.mod h1:DyFA8WVfXQ7wC3LMFQ0DUQ/6Kg5/jyqod8o/etWAMOk=
 github.com/tektoncd/pipeline v0.44.0 h1:gTiLCjTDDog3R9sRtQugiIZYqadmq5K6HArrtM1sHkU=

--- a/vendor/github.com/tektoncd/cli/pkg/cmd/taskrun/delete.go
+++ b/vendor/github.com/tektoncd/cli/pkg/cmd/taskrun/delete.go
@@ -400,7 +400,7 @@ func ownerPrFinished(cs *cli.Clients, tr v1.TaskRun) bool {
 	for _, ref := range tr.GetOwnerReferences() {
 		if ref.Kind == pipeline.PipelineRunControllerName {
 			var pr *v1.PipelineRun
-			err := actions.GetV1(pipelineRunGroupResource, cs, tr.Namespace, ref.Name, metav1.GetOptions{}, &pr)
+			err := actions.GetV1(pipelineRunGroupResource, cs, ref.Name, tr.Namespace, metav1.GetOptions{}, &pr)
 			if err != nil {
 				return false
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1361,7 +1361,7 @@ github.com/tektoncd/chains/pkg/chains/storage/pubsub
 github.com/tektoncd/chains/pkg/chains/storage/tekton
 github.com/tektoncd/chains/pkg/config
 github.com/tektoncd/chains/pkg/patch
-# github.com/tektoncd/cli v0.30.0
+# github.com/tektoncd/cli v0.30.1
 ## explicit; go 1.18
 github.com/tektoncd/cli/pkg/actions
 github.com/tektoncd/cli/pkg/bundle


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
