### PR TITLE
Bump go to 1.19 on github workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/cache@v3
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     - run: git fetch --prune --unshallow
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.18.x
+        go-version: 1.19.x
 
     - uses: actions/cache@v3
       with:


### PR DESCRIPTION
`tektoncd/cli` new release requires 1.19.