### PR TITLE
[v1.11x] Fix Global flags and --help for commands other than results

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
   enable:
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - durationcheck
     - exhaustive

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/openshift-pipelines/pipelines-as-code v0.19.0
 	github.com/spf13/cobra v1.7.0
 	github.com/tektoncd/cli v0.31.0
-	github.com/tektoncd/results/tools/tkn-results v0.0.0-20230508194947-57fa89e36c64
+	github.com/tektoncd/results/tools/tkn-results v0.0.0-20230607191238-bf9b68b17cdb
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2310,8 +2310,8 @@ github.com/tektoncd/pipeline v0.47.0 h1:zZxmp6im8/p9RaH32LgeCP6dwH/4hcsfvEQUrwGs
 github.com/tektoncd/pipeline v0.47.0/go.mod h1:7H1DeNuEJFGoExGwQTlRul2IziCPxkjXRdDdirWmoQs=
 github.com/tektoncd/results v0.5.0 h1:YvHBw4rwoYYNgoFkP5to2UcpsOOVTdILKcosRBCBJzs=
 github.com/tektoncd/results v0.5.0/go.mod h1:Zem/Q1puIqloLlx1691Zn5y1DbUQT5hCRYp5PcIWjxw=
-github.com/tektoncd/results/tools/tkn-results v0.0.0-20230508194947-57fa89e36c64 h1:gwNIsYlG4OA8lqKAJpfM+k82dfhyI0bBJdetGKXwxIo=
-github.com/tektoncd/results/tools/tkn-results v0.0.0-20230508194947-57fa89e36c64/go.mod h1:F8EuZgzjogYJStXWtxER+BRBsF1DnbeqWjOEjCKPqbA=
+github.com/tektoncd/results/tools/tkn-results v0.0.0-20230607191238-bf9b68b17cdb h1:ghh8d/QWunN5OFo+rWP4hWXpBce67S0v5Tl5C8BouLk=
+github.com/tektoncd/results/tools/tkn-results v0.0.0-20230607191238-bf9b68b17cdb/go.mod h1:F8EuZgzjogYJStXWtxER+BRBsF1DnbeqWjOEjCKPqbA=
 github.com/tektoncd/triggers v0.23.1-0.20230420080448-bf603123cc0f h1:VwUu2eWgu+c34hoocxCL2IE+1zjNeGigyNHdd9ODfL8=
 github.com/tektoncd/triggers v0.23.1-0.20230420080448-bf603123cc0f/go.mod h1:gMyEJZbLOs8+PnbjeaOa2Y2oex4IMPU9TD86WbytWIo=
 github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 h1:iGnD/q9160NWqKZZ5vY4p0dMiYMRknzctfSkqA4nBDw=

--- a/vendor/github.com/tektoncd/results/tools/tkn-results/internal/config/config.go
+++ b/vendor/github.com/tektoncd/results/tools/tkn-results/internal/config/config.go
@@ -57,7 +57,6 @@ func init() {
 	pflag.StringP("addr", "a", "", "Result API server address")
 	pflag.StringP("authtoken", "t", "", "authorization bearer token to use for authenticated requests")
 	pflag.BoolP("insecure", "", false, "insecure gprc tls communication")
-	pflag.Parse()
 }
 
 func GetConfig() (*Config, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1400,7 +1400,7 @@ github.com/tektoncd/pipeline/pkg/substitution
 ## explicit; go 1.18
 github.com/tektoncd/results/proto/pipeline/v1beta1/pipeline_go_proto
 github.com/tektoncd/results/proto/v1alpha2/results_go_proto
-# github.com/tektoncd/results/tools/tkn-results v0.0.0-20230508194947-57fa89e36c64
+# github.com/tektoncd/results/tools/tkn-results v0.0.0-20230607191238-bf9b68b17cdb
 ## explicit; go 1.17
 github.com/tektoncd/results/tools/tkn-results/cmd
 github.com/tektoncd/results/tools/tkn-results/cmd/logs


### PR DESCRIPTION
Parse function wasn't being called incorrectly in init function of results. This led to the removal of flags while integrating with opc.