### PR TITLE
[release-v1.14.x] Fix goreleaser github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,20 +9,22 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
+    - uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
+
     - uses: actions/checkout@v4
     - run: git fetch --prune --unshallow
+
     - uses: actions/setup-go@v5
       with:
         go-version: '1.20'
-
-    - uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashfiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - uses: goreleaser/goreleaser-action@v5.0.0
       with:


### PR DESCRIPTION
This will fix the goreleaser github action as it
is failing with 'no disk space left' error. This will use free disk space action to free some space on
runner and also we dont need cache step as it is
inbuilt the setup-go action now