### PR TITLE
Bump golang to 1.21 and fix golangci-lint flag

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - uses: actions/cache@v4
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - uses: actions/cache@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TKN_VERSION := $(shell sed -n '/[ ]*github.com\/tektoncd\/cli v[0-9]*\.[0-9]*\.[
 RESULTS_VERSION := $(shell sed -n '/[ ]*github.com\/tektoncd\/results v[0-9]*\.[0-9]*\.[0-9]*/ { s/.* v//;p ;}' go.mod)
 
 GO := go
-GOVERSION := 1.20
+GOVERSION := 1.21
 OPC_VERSION := devel
 BINARYNAME := opc
 GOLANGCI_LINT := golangci-lint
@@ -47,7 +47,7 @@ lint-go: ## runs go linter on all go files
 	@$(GOLANGCI_LINT) run ./... --modules-download-mode=vendor \
 							--max-issues-per-linter=0 \
 							--max-same-issues=0 \
-							--deadline 10m
+							--timeout 10m
 
 .PHONY: generate version-file version-updates updates build all vendor tidy lint-go mkbin
 


### PR DESCRIPTION
This will bump golang to work with golangci-lint latest and also fix flag in lint command