### PR TITLE
add flag to show version information from cluster

### DIFF
--- a/pkg/version.go
+++ b/pkg/version.go
@@ -8,10 +8,13 @@ import (
 	_ "embed"
 
 	paccli "github.com/openshift-pipelines/pipelines-as-code/pkg/cli"
+	tkncli "github.com/tektoncd/cli/pkg/cli"
+	tknversion "github.com/tektoncd/cli/pkg/version"
 
-	// paccli "github.com/openshift-pipelines/opc/pkg"
 	"github.com/spf13/cobra"
 )
+
+var serverFlag = "server"
 
 //go:embed version.json
 var versionFile string
@@ -27,13 +30,55 @@ type versions struct {
 	ManualApprovalGate string `json:"manualapprovalgate"`
 }
 
+func getLiveInformations(iostreams *paccli.IOStreams) error {
+	tp := &tkncli.TektonParams{}
+	cs, err := tp.Clients()
+	if err != nil {
+		return err
+	}
+	namespace := "openshift-pipelines"
+	operatorNamespace := "openshift-operators"
+
+	chainsVersion, _ := tknversion.GetChainsVersion(cs, namespace)
+	if chainsVersion != "" {
+		fmt.Fprintf(iostreams.Out, "Chains version: %s\n", chainsVersion)
+	}
+	pipelineVersion, _ := tknversion.GetPipelineVersion(cs, namespace)
+	if pipelineVersion == "" {
+		pipelineVersion = "unknown, " +
+			"pipeline controller may be installed in another namespace."
+	}
+	fmt.Fprintf(iostreams.Out, "Pipeline version: %s\n", pipelineVersion)
+	triggersVersion, _ := tknversion.GetTriggerVersion(cs, namespace)
+	if triggersVersion != "" {
+		fmt.Fprintf(iostreams.Out, "Triggers version: %s\n", triggersVersion)
+	}
+	operatorVersion, _ := tknversion.GetOperatorVersion(cs, operatorNamespace)
+	if operatorVersion != "" {
+		fmt.Fprintf(iostreams.Out, "Operator version: %s\n", operatorVersion)
+	}
+	hubVersion, _ := tknversion.GetHubVersion(cs, namespace)
+	if hubVersion != "" {
+		fmt.Fprintf(iostreams.Out, "Hub version: %s\n", hubVersion)
+	}
+	return nil
+}
+
 func VersionCommand(ioStreams *paccli.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print opc version",
 		Long:  "Print OpenShift Pipeline Client version",
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var v versions
+			server, err := cmd.Flags().GetBool(serverFlag)
+			if err != nil {
+				return err
+			}
+			if server {
+				// TODO(chmouel): pac version when it's  refactored in pac code
+				return getLiveInformations(ioStreams)
+			}
 			if err := json.Unmarshal([]byte(versionFile), &v); err != nil {
 				return fmt.Errorf("cannot unmarshall versions: %w", err)
 			}
@@ -65,5 +110,7 @@ func VersionCommand(ioStreams *paccli.IOStreams) *cobra.Command {
 			"commandType": "main",
 		},
 	}
+
+	cmd.Flags().BoolP(serverFlag, "s", false, "Get the services version information from cluster instead of the client version.")
 	return cmd
 }

--- a/pkg/version.json
+++ b/pkg/version.json
@@ -1,1 +1,7 @@
-{"pac": "0.27.2", "tkn": "0.38.0", "results": "0.11.0", "manualapprovalgate": "0.3.0", "opc": "devel"}
+{
+  "pac": "0.27.2",
+  "tkn": "0.38.0",
+  "results": "0.11.0",
+  "manualapprovalgate": "0.3.0",
+  "opc": "devel"
+}


### PR DESCRIPTION
instead of showing the client version show the live information on cluster if we pass the --live flag to opc version