### PR TITLE
Bump goreleaser config to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - sed -i 's/devel/{{ .Tag }}/' ./pkg/version.json
@@ -49,7 +50,7 @@ brews:
     repository:
       owner: openshift-pipelines
       name: opc
-    folder: Formula
+    directory: Formula
     homepage: "https://github.com/openshift-pipelines/opc"
     description: "A CLI for OpenShift Pipeline"
     install: |


### PR DESCRIPTION
This will bump goreleaser config to version 2 to
have golang 1.22.5 support