### PR TITLE
fix: Migrate golangci-lint version to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,62 +1,66 @@
-issues:
-  exclude-dirs:
-    - vendor
+version: "2"
 run:
   build-tags:
     - e2e
-linters-settings:
-  gocritic:
-    disabled-checks:
-      - unlambda
-  gofumpt:
-    extra-rules: true
 linters:
   enable:
     - asciicheck
     - bodyclose
     - copyloopvar
     - dogsled
+    - dupl
     - durationcheck
+    - errorlint
     - exhaustive
     - forbidigo
     - forcetypeassert
     - gochecknoinits
-    - dupl
-    - errcheck
-    - errorlint
-    - gofumpt
-    - goimports
-    - gosec
     - gocritic
-    - misspell
-    - gosec
-    - gosimple
-    - govet
-    - importas
-    - makezero
-    - nakedret
-    - predeclared
-    - revive
-    - staticcheck
-    - stylecheck
-    - unused
-    - unparam
-    - gochecknoinits
-      # - goconst
-      # - gocyclo
-    # - goerr113
-    # - gofmt
     - goheader
     - gomodguard
     - goprintffuncname
+    - gosec
+    - importas
+    - makezero
+    - misspell
+    - nakedret
     - nilerr
     - noctx
-      # - nolintlint (gofumpt conflict with it, create space all the time so :shrug:)
     - prealloc
+    - predeclared
     - promlinter
-    # - rowserrcheck
-    # - sqlclosecheck
+    - revive
+    - staticcheck
     - tparallel
-    #- unconvert
-    # - wastedassign
+    - unparam
     - whitespace
+  settings:
+    gocritic:
+      disabled-checks:
+        - unlambda
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - vendor
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
* With the previous version of .golangci.yml, running golanci-lint was failing with the following log
```bash            
Linting go files...
Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
Failed executing command with error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
make: *** [Makefile:50: lint-go] Error 3
```

* Using the `golangci-lint migrate` command it updates the .golangci.yml file based on the latest version of golangci-lint and the lint errors are solved