### PR TITLE
Feat: enhance opc version command to display openshift pipelines product version

### DIFF
--- a/pkg/version.json
+++ b/pkg/version.json
@@ -1,1 +1,1 @@
-{"pac": "0.35.0", "tkn": "0.41.0", "results": "0.15.0", "manualapprovalgate": "0.6.0", "opc": "devel"}
+{"pac": "0.35.0", "tkn": "0.41.0", "results": "0.15.0", "manualapprovalgate": "0.6.0", "opc": "devel", "openshiftpipelines": "test"}

--- a/pkg/version.tmpl
+++ b/pkg/version.tmpl
@@ -3,3 +3,4 @@ Tekton CLI: {{ .Tkn }}
 Pipelines as Code CLI: {{ .Pac }}
 Tekton Results CLI: {{ .Results }}
 Manual Approval Gate CLI: {{ .ManualApprovalGate }}
+OpenShift Pipelines: {{ .OpenShiftPipelines }}


### PR DESCRIPTION
It extends the existing `opc version` command to include the OpenShift product version information. 
Fixes jira: [SRVKP-2124](https://issues.redhat.com/browse/SRVKP-2124)

**Changes:**
- Added logic to detect OpenShift environment and fetch OpenShift product version
- Display OpenShift product version in `opc version` output.

**Sample Output:**
```
$ ./opc version
OpenShift Pipelines Client: devel
Tekton CLI: 0.41.0
Pipelines as Code CLI: 0.35.0
Tekton Results CLI: 0.15.0
Manual Approval Gate CLI: 0.6.0
OpenShift Pipelines: test
```