### PR TITLE
ci(github): add workflow to auto-update components

### DIFF
--- a/.github/scripts/update-patch-versions.sh
+++ b/.github/scripts/update-patch-versions.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# UPDATE_MODE controls version selection strategy:
+#   "patch"  (default) — only bump patch within the same major.minor
+#   "latest" — bump to the absolute latest stable release
+UPDATE_MODE="${UPDATE_MODE:-patch}"
+
+# Component definitions: "name|go_module|github_repo"
+COMPONENTS=(
+  "pac|github.com/openshift-pipelines/pipelines-as-code|tektoncd/pipelines-as-code"
+  "tkn|github.com/tektoncd/cli|tektoncd/cli"
+  "results|github.com/tektoncd/results|tektoncd/results"
+  "manualapprovalgate|github.com/openshift-pipelines/manual-approval-gate|openshift-pipelines/manual-approval-gate"
+)
+
+UPDATES=()
+GOMOD_CHANGED=false
+
+for entry in "${COMPONENTS[@]}"; do
+  IFS='|' read -r component module repo <<< "$entry"
+
+  module_re="${module//./\\.}"
+  current_version=$(grep -E "^\s+${module_re} v" go.mod | head -1 | awk '{print $2}' | sed 's/^v//') || true
+
+  if [[ -z "$current_version" ]]; then
+    echo "Warning: ${module} not found in go.mod, skipping ${component}"
+    continue
+  fi
+
+  echo "Checking ${component} (${module}): current v${current_version} [mode=${UPDATE_MODE}]"
+
+  all_tags=$(gh api "repos/${repo}/tags" --paginate --jq '.[].name' 2>/dev/null) || true
+
+  if [[ "$UPDATE_MODE" == "latest" ]]; then
+    target_version=$(echo "$all_tags" \
+      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+      | sed 's/^v//' \
+      | sort -V \
+      | tail -1) || true
+  else
+    major_minor="${current_version%.*}"
+    major_minor_re="${major_minor//./\\.}"
+    target_version=$(echo "$all_tags" \
+      | grep -E "^v${major_minor_re}\.[0-9]+$" \
+      | sed 's/^v//' \
+      | sort -V \
+      | tail -1) || true
+  fi
+
+  if [[ -z "$target_version" ]]; then
+    echo "  No matching tags found, skipping"
+    continue
+  fi
+
+  echo "  Target: v${target_version}"
+
+  if [[ "$target_version" != "$current_version" ]]; then
+    echo "  Update available: v${current_version} -> v${target_version}"
+    if go get "${module}@v${target_version}"; then
+      UPDATES+=("${component}: v${current_version} -> v${target_version}")
+      GOMOD_CHANGED=true
+    else
+      echo "  ERROR: go get failed for ${component}, skipping"
+    fi
+  else
+    echo "  Already up to date"
+  fi
+done
+
+TARGET_BRANCH="${TARGET_BRANCH:-}"
+OPC_REPO="openshift-pipelines/opc"
+
+if [[ -n "$TARGET_BRANCH" ]]; then
+  current_opc=$(grep -E '^OPC_VERSION\s*:=' Makefile | sed 's/.*:= *//')
+
+  echo ""
+  echo "Checking opc version: current ${current_opc} [branch=${TARGET_BRANCH}]"
+
+  opc_tags=$(gh api "repos/${OPC_REPO}/tags" --paginate --jq '.[].name' 2>/dev/null) || true
+
+  if [[ "$TARGET_BRANCH" =~ ^release-v([0-9]+\.[0-9]+)\.x$ ]]; then
+    branch_minor="${BASH_REMATCH[1]}"
+    branch_minor_re="${branch_minor//./\\.}"
+    target_opc=$(echo "$opc_tags" \
+      | grep -E "^v${branch_minor_re}\.[0-9]+$" \
+      | sed 's/^v//' \
+      | sort -V \
+      | tail -1) || true
+  elif [[ "$TARGET_BRANCH" == "main" ]]; then
+    echo "  Skipping opc version update on main (using devel)"
+  fi
+
+  if [[ -n "${target_opc:-}" && "$target_opc" != "$current_opc" ]]; then
+    echo "  Update available: ${current_opc} -> ${target_opc}"
+    sed -i "s/^OPC_VERSION := .*/OPC_VERSION := ${target_opc}/" Makefile
+    UPDATES+=("opc: v${current_opc} -> v${target_opc}")
+  else
+    echo "  Already up to date"
+  fi
+fi
+
+if [[ ${#UPDATES[@]} -eq 0 ]]; then
+  echo ""
+  echo "No updates found."
+  echo "has_updates=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if [[ "$GOMOD_CHANGED" == "true" ]]; then
+  echo ""
+  echo "Running go mod tidy..."
+  go mod tidy
+
+  echo "Running go mod vendor..."
+  go mod vendor
+fi
+
+echo ""
+echo "Regenerating version.json..."
+make generate
+
+echo ""
+echo "Updates applied:"
+for update in "${UPDATES[@]}"; do
+  echo "  - ${update}"
+done
+
+echo "has_updates=true" >> "$GITHUB_OUTPUT"
+{
+  echo "summary<<EOF"
+  for update in "${UPDATES[@]}"; do
+    echo "- ${update}"
+  done
+  echo "EOF"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-update-components.yml
+++ b/.github/workflows/auto-update-components.yml
@@ -1,0 +1,119 @@
+name: Auto-update component versions
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily at 6 AM UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Update a single branch (leave empty for all)'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    strategy:
+      matrix:
+        include:
+          - branch: main
+            update_mode: latest
+          - branch: release-v1.15.x
+            update_mode: patch
+          - branch: release-v1.20.x
+            update_mode: patch
+          - branch: release-v1.21.x
+            update_mode: patch
+          - branch: release-v1.22.x
+            update_mode: patch
+          - branch: release-v1.23.x
+            update_mode: patch
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if branch exists
+        id: check-branch
+        if: ${{ !inputs.branch || inputs.branch == matrix.branch }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MATRIX_BRANCH: ${{ matrix.branch }}
+        run: |
+          if gh api "repos/${{ github.repository }}/branches/${MATRIX_BRANCH}" --silent 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch ${MATRIX_BRANCH} does not exist, skipping"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch update script
+        if: steps.check-branch.outputs.exists == 'true'
+        run: |
+          gh api "repos/${{ github.repository }}/contents/.github/scripts/update-patch-versions.sh?ref=${{ github.ref_name }}" \
+            --jq '.content' | base64 -d > /tmp/update-patch-versions.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Checkout
+        if: steps.check-branch.outputs.exists == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Set up Go
+        if: steps.check-branch.outputs.exists == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Check for updates
+        if: steps.check-branch.outputs.exists == 'true'
+        id: update
+        run: bash /tmp/update-patch-versions.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPDATE_MODE: ${{ matrix.update_mode }}
+          TARGET_BRANCH: ${{ matrix.branch }}
+
+      - name: Create or update pull request
+        if: steps.update.outputs.has_updates == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MATRIX_BRANCH: ${{ matrix.branch }}
+          UPDATE_SUMMARY: ${{ steps.update.outputs.summary }}
+        run: |
+          PR_BRANCH="auto-update/component-versions/${MATRIX_BRANCH}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "${PR_BRANCH}"
+          git add -A
+          git commit -m "Update component versions for ${MATRIX_BRANCH}"
+          git push -f origin "${PR_BRANCH}"
+
+          EXISTING_PR=$(gh pr list \
+            --base "${MATRIX_BRANCH}" \
+            --head "${PR_BRANCH}" \
+            --json number \
+            --jq '.[0].number' 2>/dev/null) || true
+
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "PR #${EXISTING_PR} updated via force push"
+          else
+            gh pr create \
+              --base "${MATRIX_BRANCH}" \
+              --head "${PR_BRANCH}" \
+              --title "[${MATRIX_BRANCH}] Update component versions" \
+              --body "$(cat <<EOF
+          ## Component version updates
+
+          ${UPDATE_SUMMARY}
+
+          ---
+          *This PR was automatically created by the [auto-update workflow](https://github.com/${{ github.repository }}/actions/workflows/auto-update-components.yml).*
+          EOF
+          )"
+          fi


### PR DESCRIPTION
Add a daily GitHub Actions workflow and helper script that check for new releases of bundled components (pac, tkn, results, manualapprovalgate) across release branches and main. Release branches get patch-only bumps while main tracks the latest stable release. Updates go.mod, vendors dependencies, and regenerates version.json, then opens a PR.


Assisted-by: Claude Opus 4 (via Cursor)