### PR TITLE
chore: add agents repo to allowed_remote_resources

### DIFF
--- a/.fullsend/config.yaml
+++ b/.fullsend/config.yaml
@@ -16,3 +16,6 @@ create_issues:
         repos:
             - openshift-pipelines/opc
             - fullsend-ai/fullsend
+allowed_remote_resources:
+    - https://raw.githubusercontent.com/fullsend-ai/fullsend/
+    - https://raw.githubusercontent.com/fullsend-ai/agents/


### PR DESCRIPTION
## Summary

- Adds `allowed_remote_resources` with both `https://raw.githubusercontent.com/fullsend-ai/fullsend/` and `https://raw.githubusercontent.com/fullsend-ai/agents/`

This change is required before fullsend's `v0` tag can move to v0.29.0. The new version resolves agent harnesses from `fullsend-ai/agents` at runtime, and the URL must be in the config allowlist.

No behavioral change on the current v0 (v0.28.0).