### PR TITLE
[bot:1.23] Update OPC version to 1.23.1

### DIFF
--- a/pkg/version.json
+++ b/pkg/version.json
@@ -1,1 +1,8 @@
-{"pac": "0.48.1", "tkn": "0.45.0", "results": "0.19.0", "manualapprovalgate": "0.9.0", "assist": "0.1.1", "opc": "1.23.0"}
+{
+  "pac": "0.48.1",
+  "tkn": "0.45.0",
+  "results": "0.19.0",
+  "manualapprovalgate": "0.9.0",
+  "assist": "0.1.1",
+  "opc": "1.23.1"
+}


### PR DESCRIPTION
Updates pkg/version.json opc version from 1.23.0 to 1.23.1.

This must be merged before CLI binaries are built.