### PR TITLE
[bot:1.22] Update OPC version to 1.22.5

### DIFF
--- a/pkg/version.json
+++ b/pkg/version.json
@@ -1,1 +1,8 @@
-{"pac": "0.42.3", "tkn": "0.44.2", "results": "0.18.0", "manualapprovalgate": "0.8.0", "assist": "0.1.1", "opc": "1.22.0"}
+{
+  "pac": "0.42.3",
+  "tkn": "0.44.2",
+  "results": "0.18.0",
+  "manualapprovalgate": "0.8.0",
+  "assist": "0.1.1",
+  "opc": "1.22.5"
+}


### PR DESCRIPTION
Updates pkg/version.json opc version from 1.22.0 to 1.22.5.

This must be merged before CLI binaries are built.