### PR TITLE
Update component auto-update workflow branches

### DIFF
--- a/.github/workflows/auto-update-components.yml
+++ b/.github/workflows/auto-update-components.yml
@@ -23,13 +23,13 @@ jobs:
             update_mode: latest
           - branch: release-v1.15.x
             update_mode: patch
-          - branch: release-v1.20.x
-            update_mode: patch
           - branch: release-v1.21.x
             update_mode: patch
           - branch: release-v1.22.x
             update_mode: patch
           - branch: release-v1.23.x
+            update_mode: patch
+          - branch: release-v1.24.x
             update_mode: patch
       fail-fast: false
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove release-v1.20.x (EOL)
- Add release-v1.24.x to component auto-update workflow

## Test plan
- [ ] Verify workflow targets correct branches
- [ ] Confirm v1.20.x is no longer in the matrix
- [ ] Confirm v1.24.x is added to the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)