### PR TITLE
Pin jlumbroso/free-disk-space action to commit SHA (SRVKP-13569)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-    - uses: jlumbroso/free-disk-space@main
+    - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
       with:
         tool-cache: false
         android: true


### PR DESCRIPTION
## Summary

Pins the `jlumbroso/free-disk-space` GitHub Action from `@main` to a specific commit SHA to address the security vulnerability described in SRVKP-13569.

**Security Issue**: The action was using a mutable branch reference (@main), which could be compromised if the upstream repository is hijacked. Since this action runs in the release workflow with access to `secrets.GITHUB_TOKEN` and `secrets.AUR_PRIVATE_KEY`, a compromised action could tamper with release artifacts or exfiltrate secrets.

**Fix**: Pinned to commit SHA `54081f138730dfa15788a46383842cd2f914a1be` (latest from main branch).

This addresses:
- CWE-693: Improper Restriction of Rendered UI Layers or Frames
- OpenSSF Scorecard Pinned-Dependencies requirement
- SLSA v1.2 Build L2 requirement

## Test plan

- [x] Verify the workflow file has the action pinned to a commit SHA
- [x] Ensure the workflow syntax is valid
- [x] This change will be tested when the next release tag is pushed