### PR TITLE
[bot:1.22] Update OPC version to 1.22.6

### DIFF
--- a/pkg/version.json
+++ b/pkg/version.json
@@ -4,5 +4,5 @@
   "results": "0.18.0",
   "manualapprovalgate": "0.8.0",
   "assist": "0.1.1",
-  "opc": "1.22.5"
+  "opc": "1.22.6"
 }


### PR DESCRIPTION
Updates pkg/version.json opc version from 1.22.5 to 1.22.6.

This must be merged before CLI binaries are built.